### PR TITLE
Und 31: standardize envelope opening + add error if name is empty

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -41,8 +41,6 @@ const HomePage = () => {
     []
   );
 
-  const isRecentlyOpen = getCookie("is-recently-open") === "1";
-
   useEffect(() => {
     const to = query.get("to");
     const gender = query.get("g")?.toLowerCase();
@@ -68,12 +66,8 @@ const HomePage = () => {
   }, [query, cookieOptions]);
 
   useEffect(() => {
-    if (name && !isRecentlyOpen) onOpen();
-  }, [name, isRecentlyOpen, onOpen]);
-
-  useEffect(() => {
-    if (isOpen) setCookie("is-recently-open", "1", cookieOptions);
-  }, [isOpen, cookieOptions]);
+    onOpen();
+  }, [onOpen]);
 
   const onClosePlayMusic = () => {
     onClose();

--- a/components/modals/InvitationModal.tsx
+++ b/components/modals/InvitationModal.tsx
@@ -31,6 +31,8 @@ const Title = ({
 const InvitationModal = ({ isOpen, onClose, name }: InvitationModalProps) => {
   const [modalOpen, setModalOpen] = useState(isOpen);
 
+  const [valid] =  useState(!!name);
+
   useEffect(() => {
     if (isOpen) {
       setModalOpen(true); 
@@ -44,7 +46,7 @@ const InvitationModal = ({ isOpen, onClose, name }: InvitationModalProps) => {
 
   return (
     <Modal isOpen={modalOpen} onClose={handleClose} size={"full"}>
-      <CommonModalContent
+      { valid && <CommonModalContent
         justifyContent={"center"}
         alignItems={"left"}
         onClick={handleClose}
@@ -58,7 +60,20 @@ const InvitationModal = ({ isOpen, onClose, name }: InvitationModalProps) => {
           <Title fontWeight="bold" fontSize={"5xl"}>Danial</Title>
           <Text  fontSize={"lg"} fontFamily={"NewSpiritRegular"}>to <span style={{fontFamily: "NewSpiritBold" }}>{name}</span></Text>
         </Box>
-      </CommonModalContent>
+      </CommonModalContent> }
+      
+      { !valid && 
+      <CommonModalContent
+        justifyContent={"center"}
+        alignItems={"left"}
+        gap={0}
+        isOpen={isOpen}
+      >
+        <Box animation={!isOpen ? slideToTopFullAnimation : "none" } style={{animationDelay: "450ms"}}>
+        <Text fontSize={"lg"} fontFamily={"NewSpiritBold"}>This invitation may not be valid</Text>
+          <Text marginTop={{base: "4em", sm: "0"}} fontSize={"lg"} fontFamily={"NewSpiritRegular"}>Please reach out to Zafira or Danial.</Text>
+        </Box>
+      </CommonModalContent>  }
     </Modal>
   );
 };


### PR DESCRIPTION
Sekarang, flow buka invitation adalah kyk begini:

IF tidak punya nama -> tunjukkin undangan

IF punya nama:

IF pernah buka recently -> tunjukkin undangan secara langsung

IF ga pernah buka recently -> tunjukkin amplop (cover undangan)

Akan tetapi, dalam [UND-28](https://linear.app/undangan-nikah-zafira-danial/issue/UND-28/tambahin-lagu-cintaku) supaya lagu bisa dimainkan, dibutuhkan interaksi bersama website sebelumnya. Oleh karena itu, diajukan flow yang baru

IF tidak punya nama OR undangan invalid (data gender kurang dkk) ->

IF punya nama:

IF pernah buka recently -> tunjukkin undangan secara langsung

IF ga pernah buka recently -> tunjukkin amplop (cover undangan)

PR ini implements Fase 1 untuk validity: cek apakah ada nama